### PR TITLE
feat: add notification toggle and bump version to 1.5.0

### DIFF
--- a/OCR4Linux.py
+++ b/OCR4Linux.py
@@ -1,7 +1,7 @@
 # ========================================================================================================================
 # Author:
 #     Mohamed Hussein Al-Adawy
-# Version: 1.4.2
+# Version: 1.5.0
 # Description:
 #     OCR4Linux.py is a Python script that handles image preprocessing and text extraction using Tesseract OCR.
 #     The script takes an input image, processes it for optimal OCR accuracy, and extracts text while preserving
@@ -152,7 +152,7 @@ class Program:
         self.author = "Mohamed Hussein Al-Adawy"
         self.email = "mohamed.h.eladwy@gmail.com"
         self.github = "https://github.com/moheladwy/OCR4Linux"
-        self.version = "1.4.2"
+        self.version = "1.5.0"
         self.description = \
             "    OCR4Linux.py is a Python script that handles image preprocessing\n" + \
             "    and text extraction using Tesseract OCR. The script takes an input\n" + \

--- a/OCR4Linux.sh
+++ b/OCR4Linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # ========================================================================================================================
 # Author: Mohamed Hussein Al-Adawy
-# Version: 1.4.2
+# Version: 1.5.0
 # Description:
 #     OCR4Linux is a versatile text extraction tool for Linux systems that:
 #     1. Takes screenshots of selected areas using:
@@ -44,9 +44,10 @@ LOGS_FILE_NAME="$OCR4Linux_CONFIG/OCR4Linux.log"
 SLEEP_DURATION=0.5
 REMOVE_SCREENSHOT=false
 KEEP_LOGS=false
+SHOW_NOTIFICATION=false
 LANG_SPECIFIED=false
 SPECIFIED_LANGS=""
-VERSION="v1.4.2"
+VERSION="v1.5.0"
 
 langs=()
 
@@ -69,11 +70,13 @@ show_help() {
     echo "  -r                Remove screenshot in the screenshot directory"
     echo "  -d DIRECTORY      Set screenshot directory (default: $SCREENSHOT_DIRECTORY)"
     echo "  -l                Keep logs"
+    echo "  -n | --notify     Show notification after taking the screenshot"
     echo "  --lang LANGUAGES  Specify OCR languages (e.g., 'all', 'eng', 'eng+ara')"
     echo "  -v | --version    Print the package version, then exist"
     echo "  -h | --help       Show this help message, then exit"
     echo "Example:"
     echo "  OCR4Linux.sh -d $HOME/screenshots -l"
+    echo "  OCR4Linux.sh --notify"
     echo "  OCR4Linux.sh --lang eng+ara"
     echo "  OCR4Linux.sh --lang all -l"
     echo "  OCR4Linux.sh -h"
@@ -98,6 +101,10 @@ while [[ $# -gt 0 ]]; do
         ;;
     -l)
         KEEP_LOGS=true
+        shift
+        ;;
+    -n|--notify)
+        SHOW_NOTIFICATION=true
         shift
         ;;
     --lang)
@@ -230,7 +237,11 @@ choose_lang() {
 takescreenshot_wayland() {
     log_message "Taking screenshot using grimblast for Wayland..."
     sleep $SLEEP_DURATION
-    grimblast --notify copysave area "$SCREENSHOT_DIRECTORY/$SCREENSHOT_NAME"
+    if [ "$SHOW_NOTIFICATION" = true ]; then
+        grimblast --notify copysave area "$SCREENSHOT_DIRECTORY/$SCREENSHOT_NAME"
+    else
+        grimblast copysave area "$SCREENSHOT_DIRECTORY/$SCREENSHOT_NAME"
+    fi
     log_message "Screenshot saved to $SCREENSHOT_DIRECTORY/$SCREENSHOT_NAME in wayland session"
 }
 
@@ -239,6 +250,9 @@ takescreenshot_x11() {
     log_message "Taking screenshot using scrot for X11..."
     sleep $SLEEP_DURATION
     scrot -s -Z 0 -o -F "$SCREENSHOT_DIRECTORY/$SCREENSHOT_NAME"
+    if [ "$SHOW_NOTIFICATION" = true ]; then
+        notify-send "OCR4Linux" "Screenshot saved to $SCREENSHOT_DIRECTORY/$SCREENSHOT_NAME" -i camera-photo
+    fi
     log_message "Screenshot saved to $SCREENSHOT_DIRECTORY/$SCREENSHOT_NAME in x11 session"
 }
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: moheladwy <mohamed.h.eladwy@gmail.com>
 pkgname=ocr4linux-git
-pkgver=1.4.2
+pkgver=1.5.0
 pkgrel=1
 pkgdesc="OCR CLI Tool for Extracting Text from Screenshots using bash and python for both x11 and wayland."
 arch=('any')
@@ -9,6 +9,7 @@ license=('MIT')
 depends=(
   'python'
   'bash'
+  'libnotify'
   'tesseract'
   'gawk'
   'tesseract-data-eng'
@@ -31,11 +32,11 @@ sha256sums=('SKIP')
 
 pkgver() {
   cd "$srcdir/$pkgname" || exit 1
-  printf "1.4.2.r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+  printf "1.5.0.r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 }
 
 package() {
-  cd "$srcdir/$pkgname" || exit 1 
+  cd "$srcdir/$pkgname" || exit 1
 
   install -Dm755 OCR4Linux.py "${pkgdir}/usr/bin/OCR4Linux.py"
   install -Dm755 OCR4Linux.sh "${pkgdir}/usr/bin/OCR4Linux"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCR4Linux
 
-**Version:** 1.4.2
+**Version:** 1.5.0
 
 OCR4Linux is a versatile text extraction tool that allows you to take a screenshot of a selected area, extract text using OCR, and copy it to the clipboard. It supports both Wayland and X11 sessions and offers multiple language support.
 
@@ -73,7 +73,7 @@ I didn't find any easy tool in Linux that does the same thing as the PowerToys a
 
 ### Option 1: Install from AUR (Recommended)
 
-The easiest way to install OCR4Linux on Arch Linux or any Arch-based distribution is directly from the AUR:
+The easiest way to install OCR4Linux on Arch Linux or any Arch-based distribution is directly from the AUR using any AUR helper (e.g., `yay`, `paru`):
 
 ```sh
 yay -S ocr4linux-git
@@ -81,7 +81,9 @@ yay -S ocr4linux-git
 
 This will automatically install OCR4Linux and all its required dependencies.
 
-### Option 2: Manual Installation
+### Option 2: Build from Source (makepkg)
+
+You can clone the repository and build the package manually using `makepkg`:
 
 1. Clone the repository:
 
@@ -90,7 +92,24 @@ This will automatically install OCR4Linux and all its required dependencies.
     cd OCR4Linux
     ```
 
-2. Run the setup script to install the required packages and copy the necessary files to the configuration directory:
+2. Build and install the package:
+
+    ```sh
+    makepkg -si
+    ```
+
+### Option 3: Manual Installation (setup.sh)
+
+If you prefer a local installation in your home directory or want to use the automated setup script:
+
+1. Clone the repository:
+
+    ```sh
+    git clone https://github.com/moheladwy/OCR4Linux.git
+    cd OCR4Linux
+    ```
+
+2. Run the setup script:
 
     ```sh
     chmod +x setup.sh
@@ -106,17 +125,20 @@ This will automatically install OCR4Linux and all its required dependencies.
 
 ## Usage
 
-1. Run the main script to take a screenshot, extract text, and copy it to the clipboard:
+1. Run the tool to take a screenshot, extract text, and copy it to the clipboard:
 
+    If installed via AUR or `makepkg`:
     ```sh
-    chmod +x ~/.config/OCR4Linux/OCR4Linux.sh
+    OCR4Linux
+    ```
+
+    If installed via `setup.sh`:
+    ```sh
     ~/.config/OCR4Linux/OCR4Linux.sh
     ```
 
-    Or if you're in the OCR4Linux directory:
-
+    Or if you're in the source directory:
     ```sh
-    chmod +x OCR4Linux.sh
     ./OCR4Linux.sh
     ```
 
@@ -174,6 +196,7 @@ The complete OCR4Linux workflow:
 | `-r`               | Remove screenshot after processing    | `false`                      |
 | `-d DIR`           | Set screenshot directory              | `$HOME/Pictures/screenshots` |
 | `-l`               | Keep logs                             | `false`                      |
+| `-n, --notify`     | Show notification after screenshot    | `false`                      |
 | `--lang LANGUAGES` | Specify OCR languages (bypasses rofi) | Interactive selection        |
 | `-v, --version`    | Print the package version, then exit  | -                            |
 | `-h, --help`       | Show help message, then exit          | -                            |
@@ -200,33 +223,35 @@ The complete OCR4Linux workflow:
 
 ---
 
-#### Using OCR4Linux.sh
+#### Using OCR4Linux
 
 ```sh
 # Basic usage (shows interactive rofi menu)
-./OCR4Linux.sh
+OCR4Linux
 
 # Direct language specification (bypasses rofi)
-./OCR4Linux.sh --lang eng
-./OCR4Linux.sh --lang all
-./OCR4Linux.sh --lang eng+ara+fra
+OCR4Linux --lang eng
+OCR4Linux --lang all
+OCR4Linux --lang eng+ara+fra
 
 # Save logs and remove screenshot after processing
-./OCR4Linux.sh -l -r
+OCR4Linux -l -r
 
-# Custom screenshot directory with logging
-./OCR4Linux.sh -d ~/Documents/screenshots -l
+# Custom screenshot directory with logging and notification
+OCR4Linux -d ~/Documents/screenshots -l -n
 
 # Combine language specification with other options
-./OCR4Linux.sh --lang eng -l -r
-./OCR4Linux.sh --lang all -d ~/screenshots -l
+OCR4Linux --lang eng -l -r
+OCR4Linux --lang all -d ~/screenshots -l
 
 # Print version
-./OCR4Linux.sh -v
+OCR4Linux -v
 
 # Show help
-./OCR4Linux.sh -h
+OCR4Linux -h
 ```
+
+**Note:** If you are running the script manually without installation, replace `OCR4Linux` with `./OCR4Linux.sh`.
 
 #### Using OCR4Linux.py
 
@@ -269,18 +294,19 @@ python OCR4Linux.py --help
     -   Use `--lang all` only when document language is unknown
     -   Command-line specification is faster than interactive selection
 
--   **Keyboard Shortcuts**: You can create a keyboard shortcut to run the script for easy access.
+- **Keyboard Shortcuts**: You can create a keyboard shortcut to run the script for easy access.
 
     ### Example for `Hyprland` users:
 
     -   put the following lines in your `hyprland.conf` file:
 
         ```conf
-        $OCR4Linux = ~/.config/OCR4Linux/OCR4Linux.sh
-        $OCR4Linux_ENG = ~/.config/OCR4Linux/OCR4Linux.sh --lang eng
+        # If installed via AUR/makepkg
+        bind = $mainMod SHIFT, E, exec, OCR4Linux # OCR4Linux with interactive selection
+        bind = $mainMod SHIFT, T, exec, OCR4Linux --lang eng # OCR4Linux with English only
 
-        bind = $mainMod SHIFT, E, exec, $OCR4Linux # OCR4Linux with interactive selection
-        bind = $mainMod SHIFT, T, exec, $OCR4Linux_ENG # OCR4Linux with English only
+        # If installed via setup.sh
+        # bind = $mainMod SHIFT, E, exec, ~/.config/OCR4Linux/OCR4Linux.sh
         ```
 
     ### Example for `dwm` users:
@@ -288,12 +314,14 @@ python OCR4Linux.py --help
     -   put the following lines in your `config.h` file:
 
         ```c
-        static const char *ocr4linux[] = { "sh", "-c", "~/.config/OCR4Linux/OCR4Linux.sh", NULL };
-        static const char *ocr4linux_eng[] = { "sh", "-c", "~/.config/OCR4Linux/OCR4Linux.sh --lang eng", NULL };
+        /* If installed via AUR/makepkg */
+        static const char *ocr4linux[] = { "OCR4Linux", NULL };
+        static const char *ocr4linux_eng[] = { "OCR4Linux", "--lang", "eng", NULL };
 
         { MODKEY | ShiftMask, XK_e, spawn, {.v = ocr4linux } },      // OCR4Linux interactive
         { MODKEY | ShiftMask, XK_t, spawn, {.v = ocr4linux_eng } },  // OCR4Linux English only
         ```
+
 
 -   **Language Optimization**: For best results:
     -   Select only the languages present in your document

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 # ========================================================================================================================
 # Author:
 #     Mohamed Hussein Al-Adawy
-# Version: 1.4.2
+# Version: 1.5.0
 # Description:
 #     This setup script installs and configures OCR4Linux and its dependencies.
 #     It handles the installation of:
@@ -33,6 +33,7 @@ sys_requirements=(
     tesseract
     tesseract-data-eng
     tesseract-data-ara
+    libnotify
     python
     python-numpy
     python-pillow


### PR DESCRIPTION
- Add -n/--notify flag to OCR4Linux.sh to enable desktop notifications.
- Bump version to 1.5.0 across OCR4Linux.py, OCR4Linux.sh, and PKGBUILD.
- Add libnotify dependency to PKGBUILD.
- Update README.md with new usage instructions and installation options.
- closes #34 